### PR TITLE
Create images and videos with defer

### DIFF
--- a/router/schema.graphql
+++ b/router/schema.graphql
@@ -66,7 +66,7 @@ type Query
 }
 
 type Video
-  @join__type(graph: SUBGRAPH)
+  @join__type(graph: SUBGRAPH, key: "id")
 {
   id: ID!
   videoUrl: String!

--- a/subgraph/package-lock.json
+++ b/subgraph/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apollo/server": "^4.10.2",
         "@apollo/subgraph": "^2.7.2",
+        "dataloader": "^2.2.2",
         "graphql": "^16.8.1",
         "nodemon": "^3.1.0",
         "uuid": "^11.0.2"
@@ -768,6 +769,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@apollo/server": "^4.10.2",
     "@apollo/subgraph": "^2.7.2",
+    "dataloader": "^2.2.2",
     "graphql": "^16.8.1",
     "nodemon": "^3.1.0",
     "uuid": "^11.0.2"

--- a/subgraph/src/index.js
+++ b/subgraph/src/index.js
@@ -1,10 +1,12 @@
 import fs from "fs";
 import path from "path";
+import DataLoader from 'dataloader';
 import { ApolloServer } from "@apollo/server";
 import { startStandaloneServer } from "@apollo/server/standalone";
 import { buildSubgraphSchema } from "@apollo/subgraph";
 import { parse } from "graphql";
 import resolvers from "./resolvers.js";
+import { createVideosWorkflowExecutor } from "./workflowExecutor.js";
 
 const typeDefs = parse(
   fs
@@ -27,8 +29,15 @@ const server = new ApolloServer({
   plugins: [consoleLogPlugin],
 });
 
+const videoDataloader = new DataLoader(createVideosWorkflowExecutor);
+
 const { url } = await startStandaloneServer(server, {
   listen: { port: 4001 },
+  context: () => {
+    return {
+      videoDataloader,
+    };
+  }
 });
 
 console.log(`🚀 Subgraph ready at: ${url}`);

--- a/subgraph/src/resolvers.js
+++ b/subgraph/src/resolvers.js
@@ -17,6 +17,11 @@ const resolvers = {
       return 'Video';
     },
   },
+  Video: {
+    async __resolveReference(videoRepresentation, { videoDataloader }) {
+      return await videoDataloader.load(videoRepresentation.id);
+    },
+  },
 };
 
 export default resolvers;

--- a/subgraph/src/schema.graphql
+++ b/subgraph/src/schema.graphql
@@ -3,7 +3,7 @@ type Image {
   imageUrl: String!
 }
 
-type Video {
+type Video @key(fields: "id") {
   id: ID!
   videoUrl: String!
 }

--- a/subgraph/src/serverWithBusinessLogic/createAssets.js
+++ b/subgraph/src/serverWithBusinessLogic/createAssets.js
@@ -24,3 +24,13 @@ export const createVideos = async (ids) => {
     }
     return videos;
 }
+
+export const createVideosWithPlaceholder = async (ids) => {
+    const videos = [];
+    for (let i = 0; i < ids.length; i++) {
+        videos.push({
+            id: ids[i],
+        });
+    }
+    return videos;
+}

--- a/subgraph/src/serverWithBusinessLogic/workflows.js
+++ b/subgraph/src/serverWithBusinessLogic/workflows.js
@@ -3,6 +3,7 @@ import { interleaveAssets } from "./helpers.js";
 import {
   createImages,
   createVideos,
+  createVideosWithPlaceholder,
 } from "./createAssets.js";
 
 /**
@@ -23,7 +24,17 @@ export const createImagesAndVideosWorkflow = async () => {
 
   // In the actual use case, createImages and createVideos are Temporal activities
   const images = await createImages(idForImages);
-  const videos = await createVideos(idForVideos);
+  // const videos = await createVideos(idForVideos);
+  // createVideosWithPlaceholder is used for mutation with @defer
+  const videosWithPlaceholder = await createVideosWithPlaceholder(idForVideos);
 
-  return interleaveAssets(images, videos);
+  // return interleaveAssets(images, videos);
+  return interleaveAssets(images, videosWithPlaceholder);
+}
+
+/**
+ * This function represents a Temporal workflow that runs multiple activities
+ */
+export const createVideosWorkflow = async (ids) => {
+  return await createVideos(ids);
 }

--- a/subgraph/src/workflowExecutor.js
+++ b/subgraph/src/workflowExecutor.js
@@ -1,8 +1,16 @@
 import { createImagesAndVideosWorkflow } from "./serverWithBusinessLogic/workflows.js";
+import { createVideosWorkflow } from "./serverWithBusinessLogic/workflows.js";
 
 /**
  * Function to trigger a Temporal workflow
  */
 export const createImagesAndVideosWorkflowExecutor = async () => {
   return await createImagesAndVideosWorkflow();
+}
+
+/**
+ * Function to trigger a Temporal workflow
+ */
+export const createVideosWorkflowExecutor = async (ids) => {
+  return await createVideosWorkflow(ids);
 }


### PR DESCRIPTION
## Problem statement

This PR has working code to defer creating videos, the problem we are facing is that after this refactoring to support `defer` is done, the `mutation` query without `@defer` no longer works.

For example, if using this query
```
mutation createImagesAndVideos {
  createImagesAndVideos {
    ... on Image {
      id
      imageUrl
      __typename
    }
    ... on Video {
      id
      # ... @defer {
        videoUrl
      # }
      __typename
    }
  }
}
```

will return errors

```
      "message": "Cannot return null for non-nullable field Video.videoUrl.",
      "locations": [
        {
          "line": 1,
          "column": 139
        }
      ],
      "path": [
        "createImagesAndVideos",
        1,
        "videoUrl"
      ],
```

<img width="1763" alt="image" src="https://github.com/user-attachments/assets/985c9131-8484-45f2-905f-e68daadb85ad">

Making `videoUrl` optional doesn't solve the problem since the `videoUrl` will be `null`
<img width="1763" alt="image" src="https://github.com/user-attachments/assets/3aa4b8d0-4a64-4c4a-8500-f77fca1b76d2">

We are looking for a way where with and without defer in the `mutation` will give us completely results.

## Overview

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/be27ed02-0ea6-4a81-b7c2-6518d73859f1">

<details>
  <summary>Sequence diagram script</summary>

https://www.websequencediagrams.com/app

```bash
title Create Images and Videos with Defer

Client->Router: Mutation createImagesAndVideos with defer
Router->Subgraph: Query none-deferred fields
Subgraph->Server with business logic: Resolver invokes createImagesAndVideosWorkflowExecutor
Note right of Server with business logic: 
createImagesAndVideosWorkflow
- createImages
- createVideosWithPlaceholder
End note right of 
Server with business logic->Subgraph: Return data with placeholder
Subgraph->Router: Return data with placeholder
Router->Client: Return data with placeholder and "hasNext: true"
Router->Subgraph: Query deferred fields
Subgraph->Server with business logic: Resolver uses dataloader, dataloader's batch function invokes createVideosWorkflowExecutor
Note right of Server with business logic:
createVideosWorkflow
- createVideos
End note right of
Server with business logic->Subgraph: Return deferred fields
Subgraph->Router: Return deferred data
Router->Client: Return deferred data with "hasNext: false"
```
</details>

## Environment setup
Please follow the readme files

## Query
```
mutation createImagesAndVideos {
  createImagesAndVideos {
    ... on Image {
      id
      imageUrl
      __typename
    }
    ... on Video {
      id
      ... @defer {
        videoUrl
      }
      __typename
    }
  }
}
```

## Screenshot
<img width="1763" alt="image" src="https://github.com/user-attachments/assets/62b0cc5a-5592-40fa-9c9d-568b729f26a7">
<img width="1763" alt="image" src="https://github.com/user-attachments/assets/4a16f0ad-4171-4e11-9586-a0514386e995">

## Query plan
```
QueryPlan {
  Defer {
    Primary {
      {
        createImagesAndVideos {
          ... on Image {
            __typename
            id
            imageUrl
          }
          ... on Video {
            __typename
            id
          }
        }
      }:
      Fetch(service: "subgraph", id: 0) {
        {
          createImagesAndVideos {
            __typename
            ... on Image {
              __typename
              id
              imageUrl
            }
            ... on Video {
              __typename
              id
            }
          }
        }
      }
    }, [
      Deferred(depends: [0], path: "createImagesAndVideos/... on Video", label: "0") {
        {
          videoUrl
        }:
        Flatten(path: "createImagesAndVideos.@") {
          Fetch(service: "subgraph") {
            {
              ... on Video {
                __typename
                id
              }
            } =>
            {
              ... on Video {
                videoUrl
              }
            }
          },
        }
      },
    ]
  },
}
```

<img width="766" alt="image" src="https://github.com/user-attachments/assets/a8754001-0b3f-4065-99f4-2d8a9d2327cc">

